### PR TITLE
prevent exception when shredding recycled objects

### DIFF
--- a/lib/oroku_saki.rb
+++ b/lib/oroku_saki.rb
@@ -6,7 +6,7 @@ require 'objspace'
 
 module OrokuSaki
   STRING_FINALIZER =  ->(id) {
-    OrokuSaki.shred!(ObjectSpace._id2ref(id))
+    OrokuSaki.shred!(ObjectSpace._id2ref(id)) rescue nil
   }
   private_constant :STRING_FINALIZER
 


### PR DESCRIPTION
Starting with Ruby 3.1 I see frequent errors at the end of most test runs of a project that uses `ansible-vault-rb`. I'm not quite sure what's going on but I can reproduce the issue without using this gem:

```
irb(main):001:0> RUBY_VERSION
=> "3.1.0"
irb(main):002:0> s = "foo"
=> "foo"
irb(main):003:0> s.object_id
=> 14340
irb(main):004:0> ObjectSpace.define_finalizer(s, ->(id) { ObjectSpace._id2ref(id) })
=> [0, #<Proc:0x00007fbb098f89c0 (irb):4 (lambda)>]
irb(main):005:0> s = nil
=> nil
irb(main):006:0> GC.start
<internal:gc>:34: warning: Exception in finalizer #<Proc:0x00007fbb098f89c0 (irb):4 (lambda)>
(irb):4:in `_id2ref': "14340" is recycled object (RangeError)
```

Catching all errors in the finalizer is most likely a harmless thing to do and it fixes this issue.
